### PR TITLE
Fixed package.json to install an appropriate version of organigram

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -5,11 +5,11 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "@milenammay/organigram": "^1.8.0",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
-    "react-scripts": "^1.1.4",
-    "@milenammay/organigram": "link:.."
+    "react-scripts": "^1.1.4"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Hi Milena,

just a little PR for the examples folder. There was some sort of typo in the package.json (as far as I could see it) that prevented interested people using the examples.

